### PR TITLE
Remove the need to specify PHP version on build

### DIFF
--- a/PocketMine-MP.nsi
+++ b/PocketMine-MP.nsi
@@ -54,7 +54,8 @@ Section "Install"
     inetc::get /NOCANCEL https://raw.githubusercontent.com/pmmp/PocketMine-MP/master/CONTRIBUTING.md CONTRIBUTING.md 
     inetc::get /NOCANCEL https://dev.azure.com/pocketmine/a29511ba-1771-4ad2-a606-23c00a4b8b92/_apis/build/builds/${PHP_BUILD_NUMBER}/artifacts?artifactName=${PHP_ARTIFACT_NAME}&api-version=5.1-preview.5&%24format=zip $TEMP\Windows.zip
     ZipDLL::extractall $TEMP\Windows.zip $TEMP
-    ZipDLL::extractall $TEMP\Windows\${PHP_BIN_ZIP_NAME} $INSTDIR
+    FindFirst $R0 $R1 $TEMP\Windows\*php*.zip
+    ZipDLL::extractall $TEMP\Windows\$R1 $INSTDIR
     ExecWait '"$INSTDIR\vc_redist.x64.exe" /install /passive /norestart'  
     Delete "$INSTDIR\vc_redist.x64.exe"  
 SectionEnd

--- a/README.md
+++ b/README.md
@@ -14,5 +14,5 @@ You can download the latest release from [GitHub Releases](https://github.com/na
 
 #### Compiling
 ```sh
-makensis /DPHP_BUILD_NUMBER=58 /DPHP_BIN_ZIP_NAME=php-7.3.5-vc15-x64.zip "PocketMine-MP.nsi"
+makensis /DPHP_BUILD_NUMBER=64 "PocketMine-MP.nsi"
 ```


### PR DESCRIPTION
This PR removes the need to specify the inner zip file name. This works because the inner file is always a zip and will always have "php" in the name.